### PR TITLE
adler32_test: Fix warning when compiling with -Wall

### DIFF
--- a/test/adler32_test.c
+++ b/test/adler32_test.c
@@ -17,7 +17,7 @@ int main           OF((void));
 typedef struct {
     int line;
     uLong adler;
-    Byte* buf;
+    char* buf;
     int len;
     uLong expect;
 } adler32_test;
@@ -332,7 +332,7 @@ int main(void)
 {
     int i;
     for (i = 0; i < test_size; i++) {
-        test_adler32(tests[i].adler, tests[i].buf, tests[i].len,
+        test_adler32(tests[i].adler, (Byte*) tests[i].buf, tests[i].len,
                    tests[i].expect, tests[i].line);
     }
     return 0;


### PR DESCRIPTION
Compiling with -Wall yields lots of errors on adler32_test.c like:

```
test/adler32_test.c:254:26: warning: pointer targets in initialization of ‘Byte *’ {aka ‘unsigned char *’} from ‘char *’ differ in signedness [-Wpointer-sign]
    {__LINE__,0x7712aa45, "qjdwq48mBukJVUzVVfMjiqSWL5GnFSPQQDi6mE9ZaAPh9drb5tXUULwqekEH6W7kAxNQRkdV5ynU"
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/adler32_test.c:254:26: note: (near initialization for ‘tests[141].buf’)
```
This commit fixes these.